### PR TITLE
Parse any precision millis and roundtrip up to 3 millis

### DIFF
--- a/src/Timestamp.purs
+++ b/src/Timestamp.purs
@@ -4,20 +4,25 @@ import Prelude
 
 import Control.Alt ((<|>))
 import Control.Monad.Error.Class (throwError)
-import Data.DateTime (DateTime)
-import Data.Either (Either(..))
+import Data.DateTime (DateTime, millisecond, time)
+import Data.Either (Either(..), either)
+import Data.Enum (fromEnum)
 import Data.Formatter.DateTime (Formatter, FormatterCommand(..), format, unformat)
 import Data.Generic.Rep (class Generic)
 import Data.Generic.Rep.Show (genericShow)
-import Data.List (fromFoldable)
+import Data.List (List, fromFoldable)
 import Data.Newtype (class Newtype)
+import Data.String.Regex (Regex, regex)
+import Data.String.Regex as Regex
+import Data.String.Regex.Flags (noFlags)
 import Effect.Class (class MonadEffect, liftEffect)
 import Effect.Now (nowDateTime)
 import Foreign (ForeignError(..))
+import Partial.Unsafe (unsafeCrashWith)
 import Simple.JSON (class ReadForeign, class WriteForeign, readImpl, writeImpl)
 
-iso8601LongFormat :: Formatter
-iso8601LongFormat = fromFoldable
+mkIso8601Format :: Array FormatterCommand -> List FormatterCommand
+mkIso8601Format milliParser = fromFoldable $
   [ YearFull
   , Placeholder "-"
   , MonthTwoDigits
@@ -29,26 +34,29 @@ iso8601LongFormat = fromFoldable
   , MinutesTwoDigits
   , Placeholder ":"
   , SecondsTwoDigits
-  , Placeholder "."
-  , Milliseconds
-  , Placeholder "Z"
+  ] <> milliParser <>
+  [ Placeholder "Z"
   ]
 
 iso8601ShortFormat :: Formatter
-iso8601ShortFormat = fromFoldable
-  [ YearFull
-  , Placeholder "-"
-  , MonthTwoDigits
-  , Placeholder "-"
-  , DayOfMonthTwoDigits
-  , Placeholder "T"
-  , Hours24
-  , Placeholder ":"
-  , MinutesTwoDigits
-  , Placeholder ":"
-  , SecondsTwoDigits
-  , Placeholder "Z"
-  ]
+iso8601ShortFormat = mkIso8601Format []
+
+iso86011DigitMillisFormat :: Formatter
+iso86011DigitMillisFormat = mkIso8601Format [ Placeholder ".", MillisecondsShort ]
+
+iso86012DigitsMillisFormat :: Formatter
+iso86012DigitsMillisFormat = mkIso8601Format [ Placeholder ".", MillisecondsTwoDigits]
+
+iso8601LongFormat :: Formatter
+iso8601LongFormat = mkIso8601Format [ Placeholder ".", Milliseconds ]
+
+stripMillis :: String -> String
+stripMillis =
+  Regex.replace theRegex replacement
+  where
+    replacement = ".$1$2$3"
+    theRegex = regex "\\.(\\d)(\\d)(\\d)\\d+" noFlags
+      # either unsafeCrashWith identity
 
 newtype Timestamp = Timestamp DateTime
 derive newtype instance eqTimestamp :: Eq Timestamp
@@ -56,7 +64,14 @@ derive newtype instance ordTimestamp :: Ord Timestamp
 instance readTimestamp :: ReadForeign Timestamp where
   readImpl v = do
     s <- readImpl v
-    case unformat iso8601LongFormat s <|> unformat iso8601ShortFormat s of
+    let
+      as = flip unformat s
+      parsed =  as iso8601ShortFormat
+            <|> as iso86011DigitMillisFormat
+            <|> as iso86012DigitsMillisFormat
+            <|> as iso8601LongFormat
+            <|> unformat iso8601LongFormat (s # stripMillis)
+    case parsed of
       Right d -> pure (Timestamp d)
       Left e -> throwError $ pure $ ForeignError e
 
@@ -72,4 +87,11 @@ nowTimestamp :: ∀ m. MonadEffect m => m Timestamp
 nowTimestamp = liftEffect $ Timestamp <$> nowDateTime
 
 printTimestamp :: Timestamp -> String
-printTimestamp (Timestamp dt) = format iso8601LongFormat dt
+printTimestamp (Timestamp dt) = dt # format milliDigits
+  where
+    millis = dt # time # millisecond # fromEnum
+    milliDigits = case millis of
+      0                      -> iso8601ShortFormat
+      ms | ms `mod` 100 == 0 -> iso86011DigitMillisFormat
+      ms | ms `mod` 10  == 0 -> iso86012DigitsMillisFormat
+      _                      -> iso8601LongFormat

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -58,8 +58,56 @@ main = launchAff_ do
             , "2019-06-04T00:31:05Z"
             ]
           result =
-            [ "2019-06-27T14:36:51.000Z"
-            , "2019-06-04T00:31:05.000Z"
+            [ "2019-06-27T14:36:51Z"
+            , "2019-06-04T00:31:05Z"
+            ]
+          actual = map roundtrip timestamps
+        actual `shouldEqual` (map Right result)
+      it "should parse timestamps with 1 digit millis" do
+        let
+          timestamps =
+            [ "2019-06-27T14:36:51.2Z"
+            , "2019-06-04T00:31:05.9Z"
+            ]
+          result =
+            [ "2019-06-27T14:36:51.2Z"
+            , "2019-06-04T00:31:05.9Z"
+            ]
+          actual = map roundtrip timestamps
+        actual `shouldEqual` (map Right result)
+      it "should parse timestamps with 2 digit millis" do
+        let
+          timestamps =
+            [ "2019-06-27T14:36:51.22Z"
+            , "2019-06-04T00:31:05.99Z"
+            ]
+          result =
+            [ "2019-06-27T14:36:51.22Z"
+            , "2019-06-04T00:31:05.99Z"
+            ]
+          actual = map roundtrip timestamps
+        actual `shouldEqual` (map Right result)
+      it "should parse timestamps with 3 digit millis" do
+        let
+          timestamps =
+            [ "2019-06-27T14:36:51.222Z"
+            , "2019-06-04T00:31:05.789Z"
+            ]
+          result =
+            [ "2019-06-27T14:36:51.222Z"
+            , "2019-06-04T00:31:05.789Z"
+            ]
+          actual = map roundtrip timestamps
+        actual `shouldEqual` (map Right result)
+      it "should parse timestamps with more than 3 digit millis (losing precision)" do
+        let
+          timestamps =
+            [ "2019-06-27T14:36:51.2222222Z"
+            , "2019-06-04T00:31:05.789999Z"
+            ]
+          result =
+            [ "2019-06-27T14:36:51.222Z"
+            , "2019-06-04T00:31:05.789Z"
             ]
           actual = map roundtrip timestamps
         actual `shouldEqual` (map Right result)


### PR DESCRIPTION
These timestamps can have any precision, really. The library does not allow to parse them very easily. It supports only up to three digits precision. 
Now we roundtrip up to three digits and can parse longer timestamps (by cutting off any additional digits, thus losing precision and not rounding).